### PR TITLE
Fix routing issues caused by capturing groups

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -386,10 +386,10 @@ func (s *Server) Run(host, token, nodeName string, insecure bool, accessKey, acc
 		// This is a potential security risk if enabled in some clusters, hence the flag
 		r.Handle("/debug/store", newAppHandler("debugStoreHandler", s.debugStoreHandler))
 	}
-	r.Handle("/{version}/meta-data/{ram:(ram|Ram)}/security-credentials", securityHandler)
-	r.Handle("/{version}/meta-data/{ram:(ram|Ram)}/security-credentials/", securityHandler)
+	r.Handle("/{version}/meta-data/{ram:(?:ram|Ram)}/security-credentials", securityHandler)
+	r.Handle("/{version}/meta-data/{ram:(?:ram|Ram)}/security-credentials/", securityHandler)
 	r.Handle(
-		"/{version}/meta-data/{ram:(ram|Ram)}/security-credentials/{role:.*}",
+		"/{version}/meta-data/{ram:(?:ram|Ram)}/security-credentials/{role:.*}",
 		newAppHandler("roleHandler", s.roleHandler))
 	r.Handle("/healthz", newAppHandler("healthHandler", s.healthHandler))
 


### PR DESCRIPTION
As per the documentation of the mux router, the groups cannot be capturing, currently the routing is failing to get the role from the url as the capturing group is overwriting it.

Quote from the docs:

>  Groups can be used inside patterns, as long as they are non-capturing (?:re). For example:

> `r.HandleFunc("/articles/{category}/{sort:(?:asc|desc|new)}", ArticlesCategoryHandler)`
